### PR TITLE
Implement homepage benchmark behavior and verification gates

### DIFF
--- a/testing/codex-issue-1235-landing-scoreboard.md
+++ b/testing/codex-issue-1235-landing-scoreboard.md
@@ -1,0 +1,59 @@
+# codex/issue-1235-landing-scoreboard — Test Contract
+
+## Functional Behavior
+
+- The logged-out homepage selects the newest real benchmark report from the
+  server-side benchmark registry. Reports marked `sample: true` are never
+  promoted.
+- Only plain, JSON-serializable fields needed by the landing section cross the
+  Server Component to Client Component boundary: slug, title, verdict,
+  challenge-pack label, featured model, and result rows.
+- When a real report with result rows exists, the first section after the hero
+  identifies it as measured proof, renders the existing `BenchmarkScoreboard`,
+  and links to both `/benchmarks/{slug}` and `/benchmarks`.
+- When no real report exists, or the selected report has no result rows, the
+  benchmark proof section renders nothing and the rest of the homepage remains
+  unchanged.
+- The scoreboard markup remains centralized in
+  `web/src/components/marketing/benchmark-scoreboard.tsx`.
+
+## Unit Tests
+
+- Homepage benchmark selection chooses the first non-sample report from the
+  already date-sorted registry.
+- Homepage benchmark selection returns no value when every report is a sample.
+- Homepage benchmark selection returns no value when the real report has no
+  result rows.
+- The proof section renders report copy, model rows, measured scores, and both
+  expected links.
+- The proof section renders no markup when benchmark data is absent.
+
+## Integration / Functional Tests
+
+- `web/src/app/page.tsx` reads benchmark data on the server and passes the
+  selected narrow object into `HomePage`.
+- `HomePage` places the proof section immediately after the hero and before the
+  Replay feature section.
+- Existing benchmark scoreboard tests remain green.
+
+## Smoke Tests
+
+- `cd web && pnpm exec vitest run` passes.
+- `cd web && pnpm lint` passes.
+- `cd web && pnpm exec tsc --noEmit` passes.
+- `cd web && pnpm build` passes.
+
+## E2E Tests
+
+N/A — this change promotes repository-backed static benchmark content and does
+not introduce a new interactive workflow.
+
+## Manual / cURL Tests
+
+- Render the logged-out homepage at 375px and 1440px and confirm the scoreboard
+  remains readable through horizontal scrolling on narrow screens.
+- Confirm "Reproduce this run" opens the selected benchmark detail route and
+  "Browse all benchmarks" opens the benchmark hub.
+- Confirm the section is absent when all benchmark reports are temporarily
+  treated as samples in a test fixture; no production content is modified for
+  this check.

--- a/web/src/app/homepage-benchmark.test.tsx
+++ b/web/src/app/homepage-benchmark.test.tsx
@@ -1,0 +1,125 @@
+import { Children, type ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BenchmarkReport } from "@/lib/benchmarks";
+
+const mocks = vi.hoisted(() => ({
+  getAllReports: vi.fn(),
+  hasPublishedBenchmarks: vi.fn(),
+  isReturningVisitor: vi.fn(),
+  redirect: vi.fn(),
+  withAuth: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: mocks.withAuth,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("@/lib/auth/returning", () => ({
+  isReturningVisitor: mocks.isReturningVisitor,
+}));
+
+vi.mock("@/lib/benchmarks", () => ({
+  getAllReports: mocks.getAllReports,
+  hasPublishedBenchmarks: mocks.hasPublishedBenchmarks,
+}));
+
+vi.mock("@/lib/changelog", () => ({
+  getChangelogPeriods: () => [{ startDate: "2026-08-01" }],
+}));
+
+vi.mock("@/components/marketing/json-ld", () => ({
+  JsonLd: () => null,
+  SITE_URL: "https://www.agentclash.dev",
+  faqSchema: () => ({}),
+  organizationSchema: () => ({}),
+  productSchema: () => ({}),
+  softwareSourceCodeSchema: () => ({}),
+  websiteSchema: () => ({}),
+}));
+
+vi.mock("./landing", () => ({
+  default: () => null,
+}));
+
+import RootPage from "./page";
+
+function report(): BenchmarkReport {
+  return {
+    slug: "measured-report",
+    title: "Measured benchmark",
+    date: "2026-06-07",
+    description: "A measured comparison.",
+    author: "AgentClash",
+    featuredModel: "Model Alpha",
+    verdict: "Model Alpha won.",
+    challengePack: "Expression Evaluator Arena v1",
+    sample: false,
+    runShareUrl: "",
+    tasks: [],
+    results: [
+      {
+        model: "Model Alpha",
+        provider: "Provider",
+        rank: 1,
+        winner: true,
+        composite: 1,
+        correctness: 1,
+        reliability: 1,
+        latency: null,
+        cost: 0.8,
+        costPerCorrectUsd: null,
+      },
+    ],
+  };
+}
+
+function homePageProps(page: ReactElement) {
+  const children = Children.toArray(
+    (page.props as { children: ReactElement[] }).children,
+  );
+  return (
+    children.at(-1) as ReactElement<{
+      benchmark?: { slug: string; results: Array<{ model: string }> };
+      returning?: boolean;
+    }>
+  ).props;
+}
+
+describe("homepage benchmark data", () => {
+  beforeEach(() => {
+    mocks.getAllReports.mockReset();
+    mocks.hasPublishedBenchmarks.mockReset();
+    mocks.isReturningVisitor.mockReset();
+    mocks.redirect.mockReset();
+    mocks.withAuth.mockReset();
+    mocks.withAuth.mockResolvedValue({ user: null });
+    mocks.isReturningVisitor.mockResolvedValue(false);
+  });
+
+  it("passes the measured report from the server registry into HomePage", async () => {
+    mocks.hasPublishedBenchmarks.mockReturnValue(true);
+    mocks.getAllReports.mockReturnValue([report()]);
+
+    const props = homePageProps((await RootPage()) as ReactElement);
+
+    expect(props.returning).toBe(false);
+    expect(props.benchmark).toMatchObject({
+      slug: "measured-report",
+      results: [{ model: "Model Alpha" }],
+    });
+  });
+
+  it("passes no benchmark and skips the report scan when none are published", async () => {
+    mocks.hasPublishedBenchmarks.mockReturnValue(false);
+
+    const props = homePageProps((await RootPage()) as ReactElement);
+
+    expect(props.benchmark).toBeUndefined();
+    expect(mocks.getAllReports).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -21,9 +21,11 @@ import { PricingBlock } from "@/components/marketing/pricing-block";
 import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block";
 import { TrackBox } from "@/components/marketing/track-box";
 import { AgentPromoBanner } from "@/components/marketing/agent-promo-banner";
+import { HomepageBenchmarkProof } from "@/components/marketing/homepage-benchmark-proof";
 import { MatrixMark } from "@/components/marketing/matrix-mark";
 import { COMPARISON_COLUMNS, COMPARISON_ROWS } from "@/lib/comparison-data";
 import { HOME_FAQ } from "@/lib/home-faq";
+import type { HomepageBenchmarkData } from "@/lib/homepage-benchmark";
 
 function ClashMark({
   className = "",
@@ -1413,8 +1415,10 @@ const LANDING_FEATURES: Array<{
 
 export default function HomePage({
   returning = false,
+  benchmark,
 }: {
   returning?: boolean;
+  benchmark?: HomepageBenchmarkData;
 }) {
   const { user, loading: authLoading } = useAuth();
 
@@ -1592,6 +1596,29 @@ export default function HomePage({
           </div>
         </div>
       </LuminousGrid>
+
+      <HomepageBenchmarkProof
+        benchmark={benchmark}
+        actions={
+          benchmark ? (
+            <>
+              <Link
+                href={`/benchmarks/${benchmark.slug}`}
+                className="inline-flex items-center gap-2 font-medium text-white transition-colors hover:text-white/75"
+              >
+                Reproduce this run
+                <ArrowRight className="size-4" aria-hidden />
+              </Link>
+              <Link
+                href="/benchmarks"
+                className="text-white/50 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/80 hover:decoration-white/40"
+              >
+                Browse all benchmarks
+              </Link>
+            </>
+          ) : null
+        }
+      />
 
       {/* ── Feature · Replay ────────────────────────────────────── */}
       <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/components/marketing/json-ld";
 import { getChangelogPeriods } from "@/lib/changelog";
 import { HOME_FAQ } from "@/lib/home-faq";
+import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
+import { selectHomepageBenchmark } from "@/lib/homepage-benchmark";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import { isReturningVisitor } from "@/lib/auth/returning";
 import { markdownAlternate } from "@/lib/seo";
@@ -93,6 +95,9 @@ export default async function RootPage() {
   const { user } = await withAuth();
   if (user) redirect("/dashboard");
   const returning = await isReturningVisitor();
+  const benchmark = hasPublishedBenchmarks()
+    ? selectHomepageBenchmark(getAllReports())
+    : undefined;
   return (
     <>
       <JsonLd
@@ -105,7 +110,7 @@ export default async function RootPage() {
           faqSchema(HOME_FAQ),
         ]}
       />
-      <HomePage returning={returning} />
+      <HomePage returning={returning} benchmark={benchmark} />
     </>
   );
 }

--- a/web/src/components/marketing/homepage-benchmark-proof.test.tsx
+++ b/web/src/components/marketing/homepage-benchmark-proof.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import Link from "next/link";
+
+import type { HomepageBenchmarkData } from "@/lib/homepage-benchmark";
+import { HomepageBenchmarkProof } from "./homepage-benchmark-proof";
+
+const benchmark: HomepageBenchmarkData = {
+  slug: "measured-report",
+  title: "Four models on an expression evaluator",
+  verdict: "Model Alpha completed the task with fewer turns.",
+  challengePack: "Expression Evaluator Arena v1",
+  featuredModel: "Model Alpha",
+  results: [
+    {
+      model: "Model Alpha",
+      provider: "Provider",
+      rank: 1,
+      winner: true,
+      composite: 1,
+      correctness: 1,
+      reliability: 1,
+      latency: null,
+      cost: 0.8,
+      costPerCorrectUsd: null,
+    },
+    {
+      model: "Model Beta",
+      provider: "Provider",
+      rank: 2,
+      winner: false,
+      composite: 0.75,
+      correctness: 0.8,
+      reliability: 0.7,
+      latency: null,
+      cost: 0.6,
+      costPerCorrectUsd: null,
+    },
+  ],
+};
+
+describe("HomepageBenchmarkProof", () => {
+  it("renders measured report proof with the shared scoreboard and links", () => {
+    const html = renderToStaticMarkup(
+      <HomepageBenchmarkProof
+        benchmark={benchmark}
+        actions={
+          <>
+            <Link href="/benchmarks/measured-report">Reproduce this run</Link>
+            <Link href="/benchmarks">Browse all benchmarks</Link>
+          </>
+        }
+      />,
+    );
+
+    expect(html).toContain("Measured benchmark");
+    expect(html).toContain("A real run. A result you can reproduce.");
+    expect(html).toContain("Four models on an expression evaluator");
+    expect(html).toContain("Model Alpha completed the task with fewer turns.");
+    expect(html).toContain("Expression Evaluator Arena v1");
+    expect(html).toContain("Model Alpha");
+    expect(html).toContain("Model Beta");
+    expect(html).toContain("Composite");
+    expect(html).toContain('href="/benchmarks/measured-report"');
+    expect(html).toContain("Reproduce this run");
+    expect(html).toContain('href="/benchmarks"');
+    expect(html).toContain("Browse all benchmarks");
+  });
+
+  it("renders nothing when there is no measured benchmark", () => {
+    expect(
+      renderToStaticMarkup(<HomepageBenchmarkProof benchmark={undefined} />),
+    ).toBe("");
+  });
+});

--- a/web/src/components/marketing/homepage-benchmark-proof.tsx
+++ b/web/src/components/marketing/homepage-benchmark-proof.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+import { BenchmarkScoreboard } from "@/components/marketing/benchmark-scoreboard";
+import type { HomepageBenchmarkData } from "@/lib/homepage-benchmark";
+
+export function HomepageBenchmarkProof({
+  benchmark,
+  actions,
+}: {
+  benchmark?: HomepageBenchmarkData;
+  actions?: ReactNode;
+}) {
+  if (!benchmark || benchmark.results.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="homepage-benchmark-heading"
+      className="border-t border-white/[0.06] px-8 py-24 sm:px-12 sm:py-32"
+    >
+      <div className="mx-auto grid max-w-[1440px] gap-12 lg:grid-cols-[0.72fr_1.28fr] lg:items-center lg:gap-16">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/40">
+            Measured benchmark
+          </p>
+          <h2
+            id="homepage-benchmark-heading"
+            className="mt-4 max-w-[18ch] font-sans text-[clamp(2.25rem,5vw,4.5rem)] font-semibold leading-[1.02] tracking-tight"
+          >
+            A real run. A result you can reproduce.
+          </h2>
+          <p className="mt-7 max-w-[48ch] text-base font-medium leading-7 text-white/85 sm:text-lg">
+            {benchmark.title}
+          </p>
+          <p className="mt-4 max-w-[52ch] text-base leading-7 text-white/55">
+            {benchmark.verdict}
+          </p>
+          {benchmark.challengePack ? (
+            <p className="mt-5 font-mono text-xs leading-6 text-white/40">
+              Challenge: {benchmark.challengePack}
+            </p>
+          ) : null}
+          {actions ? (
+            <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+              {actions}
+            </div>
+          ) : null}
+        </div>
+
+        <BenchmarkScoreboard
+          results={benchmark.results}
+          featuredModel={benchmark.featuredModel}
+        />
+      </div>
+    </section>
+  );
+}

--- a/web/src/lib/homepage-benchmark.test.ts
+++ b/web/src/lib/homepage-benchmark.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { BenchmarkReport } from "./benchmarks";
+import { selectHomepageBenchmark } from "./homepage-benchmark";
+
+function report(overrides: Partial<BenchmarkReport> = {}): BenchmarkReport {
+  return {
+    slug: "measured-report",
+    title: "Measured benchmark",
+    date: "2026-06-07",
+    description: "A measured comparison.",
+    author: "AgentClash",
+    featuredModel: "Model Alpha",
+    verdict: "Model Alpha won with fewer turns.",
+    challengePack: "Expression Evaluator Arena v1",
+    sample: false,
+    runShareUrl: "",
+    tasks: [],
+    results: [
+      {
+        model: "Model Alpha",
+        provider: "Provider",
+        rank: 1,
+        winner: true,
+        composite: 1,
+        correctness: 1,
+        reliability: 1,
+        latency: null,
+        cost: 0.8,
+        costPerCorrectUsd: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("selectHomepageBenchmark", () => {
+  it("selects the first non-sample report from the date-sorted registry", () => {
+    const selected = selectHomepageBenchmark([
+      report({ slug: "newer-sample", sample: true }),
+      report({ slug: "newest-real", title: "Newest real report" }),
+      report({ slug: "older-real", title: "Older real report" }),
+    ]);
+
+    expect(selected).toMatchObject({
+      slug: "newest-real",
+      title: "Newest real report",
+      featuredModel: "Model Alpha",
+    });
+  });
+
+  it("returns undefined when every report is illustrative", () => {
+    expect(
+      selectHomepageBenchmark([
+        report({ slug: "sample-a", sample: true }),
+        report({ slug: "sample-b", sample: true }),
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the newest real report has no result rows", () => {
+    expect(
+      selectHomepageBenchmark([report({ results: [] })]),
+    ).toBeUndefined();
+  });
+
+  it("returns only fields needed by the client-side landing section", () => {
+    expect(selectHomepageBenchmark([report()])).toEqual({
+      slug: "measured-report",
+      title: "Measured benchmark",
+      verdict: "Model Alpha won with fewer turns.",
+      challengePack: "Expression Evaluator Arena v1",
+      featuredModel: "Model Alpha",
+      results: [
+        {
+          model: "Model Alpha",
+          provider: "Provider",
+          rank: 1,
+          winner: true,
+          composite: 1,
+          correctness: 1,
+          reliability: 1,
+          latency: null,
+          cost: 0.8,
+          costPerCorrectUsd: null,
+        },
+      ],
+    });
+  });
+});

--- a/web/src/lib/homepage-benchmark.ts
+++ b/web/src/lib/homepage-benchmark.ts
@@ -1,0 +1,30 @@
+import type { BenchmarkReport, BenchmarkResult } from "./benchmarks";
+
+export type HomepageBenchmarkData = {
+  slug: string;
+  title: string;
+  verdict: string;
+  challengePack: string;
+  featuredModel: string;
+  results: BenchmarkResult[];
+};
+
+/**
+ * Select the newest measured report for the homepage. `getAllReports()` returns
+ * reports newest-first, so the first non-sample entry is the one to promote.
+ */
+export function selectHomepageBenchmark(
+  reports: readonly BenchmarkReport[],
+): HomepageBenchmarkData | undefined {
+  const report = reports.find((candidate) => !candidate.sample);
+  if (!report || report.results.length === 0) return undefined;
+
+  return {
+    slug: report.slug,
+    title: report.title,
+    verdict: report.verdict,
+    challengePack: report.challengePack,
+    featuredModel: report.featuredModel,
+    results: report.results,
+  };
+}


### PR DESCRIPTION
<!-- Thanks for contributing to AgentClash! Keep PRs focused. -->

## What & why
This pull request introduces a new feature that promotes a real, measured benchmark report to the logged-out homepage, providing users with reproducible benchmark proof and improving transparency. It includes server-side selection of the newest valid benchmark, a new client component for rendering the proof section, and comprehensive tests to ensure correct behavior. Only the minimal, necessary benchmark data is passed from server to client, and the markup for the scoreboard remains centralized.

**Homepage Benchmark Proof Feature**

- Added a new function `selectHomepageBenchmark` in `web/src/lib/homepage-benchmark.ts` to select the newest real (non-sample) benchmark report with result rows, returning only the fields needed for the homepage.
- Created the `HomepageBenchmarkProof` component in `web/src/components/marketing/homepage-benchmark-proof.tsx` to render the proof section, including the shared `BenchmarkScoreboard` and action links, or nothing if no valid report is available.
- Updated `web/src/app/page.tsx` and `web/src/app/landing.tsx` to select the homepage benchmark on the server, pass it to `HomePage`, and render the new proof section after the hero. [[1]](diffhunk://#diff-7fc3ee84083b5317c29d04778459a51adfde3c444f6d26cdda3d1a76585d2a3fR15-R16) [[2]](diffhunk://#diff-7fc3ee84083b5317c29d04778459a51adfde3c444f6d26cdda3d1a76585d2a3fR98-R100) [[3]](diffhunk://#diff-7fc3ee84083b5317c29d04778459a51adfde3c444f6d26cdda3d1a76585d2a3fL108-R113) [[4]](diffhunk://#diff-6230548935fce263978b2b0d9509b339f1c1b675272aa5d438c4ec358f4e7a61R24-R28) [[5]](diffhunk://#diff-6230548935fce263978b2b0d9509b339f1c1b675272aa5d438c4ec358f4e7a61R1418-R1421) [[6]](diffhunk://#diff-6230548935fce263978b2b0d9509b339f1c1b675272aa5d438c4ec358f4e7a61R1600-R1622)

**Testing and Documentation**

- Added comprehensive unit and integration tests for benchmark selection and rendering in `web/src/lib/homepage-benchmark.test.ts`, `web/src/app/homepage-benchmark.test.tsx`, and `web/src/components/marketing/homepage-benchmark-proof.test.tsx`. [[1]](diffhunk://#diff-eda8adb34469a7f7d4605a77827c7ce9f228603d486f42b7b11eab06c8ecf469R1-R90) [[2]](diffhunk://#diff-e9ad3364edc26c753123275b61a59bd346eda7df00442f8f2aea639d10f5008fR1-R125) [[3]](diffhunk://#diff-ed845ef89d3d51e68f9c871ea9dc289748a8123f7bc58c598b83811a165ee697R1-R75)
- Documented the contract, expected behaviors, and test coverage for the feature in `testing/codex-issue-1235-landing-scoreboard.md`.

<!-- What does this change and why? Link any related issue (e.g. Closes #123). -->

## Type

<!-- Conventional Commit type used in the title: fix / feat / feat! / docs / chore / ci / refactor / test -->

## Areas touched

- [ ] Backend (`backend/`)
- [ ] CLI (`cli/`)
- [ ] Frontend (`web/`)
- [ ] Docs / other

## Verification

<!-- How did you test this? Paste commands/output. -->

- [ ] Builds, `vet`/`lint`, and type checks pass for every part I touched
- [ ] Tests added/updated (happy path and a failure path where applicable)
- [ ] If a backend route changed, `docs/api-server/openapi.yaml` is updated
- [ ] If DB queries changed, `sqlc generate` was run

## Contributor License Agreement

<!-- See CONTRIBUTOR_LICENSE_AGREEMENT.md. Checking the box below records your agreement to the CLA. -->

- [ ] I have read and agree to the project CLA (CONTRIBUTOR_LICENSE_AGREEMENT.md), and I have the right to submit these contributions under it

## Notes for reviewers

<!-- Anything reviewers should focus on, follow-ups, or known gaps. -->
